### PR TITLE
Add check-in timestamp to view

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -200,6 +200,7 @@ class CheckInResponse(CheckInBase):
     user_id: int
     created_at: datetime
     poi: POIResponse
+    checkin_count: int = Field(..., description="Total number of check-ins at this place by the user")
 
     class Config:
         from_attributes = True

--- a/backend/app/routers/checkins.py
+++ b/backend/app/routers/checkins.py
@@ -78,8 +78,29 @@ async def get_user_checkins(
         CheckIn.user_id == current_user.id
     ).count()
 
-    # Convert to response format with POI details
-    checkin_responses = [get_checkin_with_poi(db, checkin) for checkin in checkins]
+    # Get check-in counts for each unique place in the result set
+    checkin_counts = {}
+    if checkins:
+        # Build a query to count check-ins per place
+        for checkin in checkins:
+            key = (checkin.poi_osm_type, checkin.poi_osm_id)
+            if key not in checkin_counts:
+                count = db.query(CheckIn).filter(
+                    CheckIn.user_id == current_user.id,
+                    CheckIn.poi_osm_type == checkin.poi_osm_type,
+                    CheckIn.poi_osm_id == checkin.poi_osm_id
+                ).count()
+                checkin_counts[key] = count
+
+    # Convert to response format with POI details and check-in counts
+    checkin_responses = [
+        get_checkin_with_poi(
+            db,
+            checkin,
+            checkin_counts.get((checkin.poi_osm_type, checkin.poi_osm_id), 1)
+        )
+        for checkin in checkins
+    ]
 
     return CheckInListResponse(
         checkins=checkin_responses,
@@ -244,7 +265,7 @@ async def export_checkins_geojson(
         }
     )
 
-def get_checkin_with_poi(db: Session, checkin: CheckIn) -> CheckInResponse:
+def get_checkin_with_poi(db: Session, checkin: CheckIn, checkin_count: int = None) -> CheckInResponse:
     """Helper function to get checkin with POI details."""
     poi = db.query(POI).filter(
         POI.osm_type == checkin.poi_osm_type,
@@ -254,6 +275,14 @@ def get_checkin_with_poi(db: Session, checkin: CheckIn) -> CheckInResponse:
     if not poi:
         raise HTTPException(status_code=404, detail="Associated place not found")
 
+    # Calculate check-in count if not provided
+    if checkin_count is None:
+        checkin_count = db.query(CheckIn).filter(
+            CheckIn.user_id == checkin.user_id,
+            CheckIn.poi_osm_type == checkin.poi_osm_type,
+            CheckIn.poi_osm_id == checkin.poi_osm_id
+        ).count()
+
     # Create CheckInResponse with POI included
     return CheckInResponse(
         id=checkin.id,
@@ -262,5 +291,6 @@ def get_checkin_with_poi(db: Session, checkin: CheckIn) -> CheckInResponse:
         user_id=checkin.user_id,
         created_at=checkin.created_at,
         comment=checkin.comment,
-        poi=POIResponse.model_validate(poi)
+        poi=POIResponse.model_validate(poi),
+        checkin_count=checkin_count
     )

--- a/frontend/src/pages/CheckIns.tsx
+++ b/frontend/src/pages/CheckIns.tsx
@@ -161,6 +161,26 @@ export function CheckIns() {
     return Object.entries(groups)
   }, [checkins])
 
+  // Helper function to get accent color based on check-in frequency
+  const getAccentColor = (count: number) => {
+    if (count === 1) return 'border-l-gray-300'
+    if (count === 2) return 'border-l-blue-400'
+    if (count === 3) return 'border-l-green-400'
+    if (count === 4) return 'border-l-yellow-400'
+    if (count >= 5 && count < 10) return 'border-l-orange-400'
+    return 'border-l-purple-500'
+  }
+
+  // Helper function to get badge color based on check-in frequency
+  const getBadgeColor = (count: number) => {
+    if (count === 1) return 'bg-gray-100 text-gray-700'
+    if (count === 2) return 'bg-blue-100 text-blue-700'
+    if (count === 3) return 'bg-green-100 text-green-700'
+    if (count === 4) return 'bg-yellow-100 text-yellow-700'
+    if (count >= 5 && count < 10) return 'bg-orange-100 text-orange-700'
+    return 'bg-purple-100 text-purple-700'
+  }
+
   return (
     <div>
       {/* Header */}
@@ -220,22 +240,29 @@ export function CheckIns() {
                   {dayCheckins.map((checkin) => (
                     <div key={checkin.id}>
                       {/* Check-in card */}
-                      <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow">
+                      <div className={`bg-white border border-gray-200 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow border-l-4 ${getAccentColor(checkin.checkin_count)}`}>
                         <div className="flex items-start space-x-3">
                           <div className="text-gray-600 flex-shrink-0">
                             {getCategoryIcon(checkin.poi.class || checkin.poi.category || 'misc', { size: 24 })}
                           </div>
                           <div className="flex-1 min-w-0">
                             <div className="flex items-start justify-between gap-2">
-                              <Link
-                                to={`/places/${checkin.poi.osm_type}/${checkin.poi.osm_id}`}
-                                className="font-semibold text-gray-900 hover:text-primary-600 transition-colors line-clamp-1"
-                              >
-                                {checkin.poi.name || 'Unnamed Location'}
-                              </Link>
-                              <span className="text-xs text-gray-500 whitespace-nowrap flex-shrink-0">
-                                {format(new Date(checkin.created_at), 'h:mm a')}
-                              </span>
+                              <div className="flex-1 min-w-0">
+                                <Link
+                                  to={`/places/${checkin.poi.osm_type}/${checkin.poi.osm_id}`}
+                                  className="font-semibold text-gray-900 hover:text-primary-600 transition-colors line-clamp-1"
+                                >
+                                  {checkin.poi.name || 'Unnamed Location'}
+                                </Link>
+                              </div>
+                              <div className="flex items-center gap-2 flex-shrink-0">
+                                <span className={`text-xs px-2 py-1 rounded-full font-medium ${getBadgeColor(checkin.checkin_count)}`}>
+                                  {checkin.checkin_count}x
+                                </span>
+                                <span className="text-xs text-gray-500 whitespace-nowrap">
+                                  {format(new Date(checkin.created_at), 'h:mm a')}
+                                </span>
+                              </div>
                             </div>
 
                             <p className="text-sm text-gray-600 mt-0.5">
@@ -306,9 +333,14 @@ export function CheckIns() {
                             )}
 
                             <div className="mt-3 flex items-center justify-between text-xs">
-                              <span className="text-gray-400">
-                                {formatDistanceToNow(new Date(checkin.created_at), { addSuffix: true })}
-                              </span>
+                              <div className="flex flex-col">
+                                <span className="text-gray-500 font-medium">
+                                  {formatDistanceToNow(new Date(checkin.created_at), { addSuffix: true })}
+                                </span>
+                                <span className="text-gray-400 text-xs">
+                                  {format(new Date(checkin.created_at), 'MMM d, yyyy @ h:mm a')}
+                                </span>
+                              </div>
                               <div className="flex items-center gap-2">
                                 <DoubleConfirmButton
                                   onConfirm={() => handleDeleteCheckin(checkin.id)}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -48,6 +48,7 @@ export interface CheckIn {
   comment?: string
   created_at: string
   poi: POI
+  checkin_count: number
 }
 
 export interface AuthToken {


### PR DESCRIPTION
This commit enhances the check-in history view with:
- Check-in count per place displayed as a badge
- Color-coded accent borders on cards based on frequency (gray for 1x, blue for 2x, green for 3x, yellow for 4x, orange for 5-9x, purple for 10+)
- Enhanced timestamp display showing both relative time and full datetime
- Backend API now includes checkin_count in CheckInResponse
- Check-ins are already sorted by most recent first (created_at DESC)

The visual feedback helps users quickly identify their favorite spots.